### PR TITLE
fix the variable name for the ConsumerConfiguration

### DIFF
--- a/src/jetstream/consumer/manage.jl
+++ b/src/jetstream/consumer/manage.jl
@@ -1,6 +1,6 @@
 
 function consumer_create_or_update(connection::NATS.Connection, config::ConsumerConfiguration, stream::String)
-    consumer_name = @something config.name consumer_config.durable_name randstring(20)
+    consumer_name = @something config.name config.durable_name randstring(20)
     subject = "\$JS.API.CONSUMER.CREATE.$stream.$consumer_name"
     req_data = Dict(:stream_name => stream, :config => config)
     # if !isnothing(action) #TODO: handle action


### PR DESCRIPTION
Hi! I understand if this repository is not under very active development. This is just a small typo fix when creating a JetStream ConsumerConfiguration.

The problem only occurs when no name is set for the ConsumerConfiguration, and then the code tries to default to the durable name, but the variable name is misspelled.